### PR TITLE
minimap will stay enlarged when selecting multiple nodes in adminst…

### DIFF
--- a/client/src/components/Minimap/Minimap.tsx
+++ b/client/src/components/Minimap/Minimap.tsx
@@ -103,7 +103,9 @@ function Minimap(props: MinimapProps) {
         setRotation,
       );
     } else if (!editing && !selectedNode) {
-      props.updateMinimapEnlarged(false);
+      if (!user?.isAdmin) {
+        props.updateMinimapEnlarged(false);
+      }
       props.onClickNode(node.tiles_id);
       props.setNodeState({
         x_position: node.x,


### PR DESCRIPTION
**If need help setting up project:**
1. `./run_project_docker.sh` at prism root.
2.  Click Y for downloading mongodump data and if you need docker images built, click Y for that option too.
3. Run `./server/get_mongodumps.sh`
4. `mongorestore ./server/prism_mongodumps/anlb/mongodump_andrew_liveris_prd_2024_02_08/`
5. Navigate to `./server/env`
6. Change line 3:
```
DATABASE_URL=mongodb://mongodb:27017/andrew_liveris
```
Andrew liveris was used here as an example but feel free to use any other site.. like aeb for instance
7. Refer to **Setup**

**Setup:**
Please make sure you have client,server and db running.
Run `docker ps` to see your available containers. If no containers exist, run `docker compose up` or `docker compose up --build`
```bash
git checkout feature/TEAM24-298
```

**Testing:**
1. You are going to have to test manually, check that when the variable `USE_SSO:` is false in `env.js` in the client side, the minimap does not get minimized 

Ticket:
https://elipse-uq.atlassian.net/browse/TEAM24-298?atlOrigin=eyJpIjoiMzUxY2I0M2NmYTYxNGNhZjllMzQ4YTY3NjczYTMzMDEiLCJwIjoiaiJ9