### PR TITLE
fixed pov obscuration issue

### DIFF
--- a/client/src/sass/partials/_minimap.module.scss
+++ b/client/src/sass/partials/_minimap.module.scss
@@ -374,6 +374,7 @@
     rgba(255, 136, 0, 0.1) 60%,
     transparent
   );
+  pointer-events: none;
   width: 50px;
   height: 50px;
   border-radius: 0 0 50px 0;


### PR DESCRIPTION
**If need help setting up project:**
1. `./run_project_docker.sh` at prism root.
2.  Click Y for downloading mongodump data and if you need docker images built, click Y for that option too.
4. `mongorestore ./server/prism_mongodumps/anlb/mongodump_andrew_liveris_prd_2024_02_08/`
5. Navigate to `./server/env`
6. Change line 3:
```
DATABASE_URL=mongodb://mongodb:27017/andrew_liveris
```
Andrew liveris was used here as an example but feel free to use any other site.. like aeb for instance
7. Refer to **Setup**

**Setup:**
Please make sure you have client,server and db running.
Run `docker ps` to see your available containers. If no containers exist, run `docker compose up` or `docker compose up --build`
```bash
git checkout bugfix/TEAM24-301
```

**Testing:**
1. You are going to have to test manually, Users need to have the capability to click on any node within the collapsed minimap, even if the node overlaps with the POV indicator.
Ticket:
https://elipse-uq.atlassian.net/browse/TEAM24-301?atlOrigin=eyJpIjoiZjVhMTM1OTkyNDdmNDg2Yjg0NzRjYjczYTUwZTlhNzAiLCJwIjoiaiJ9