### PR TITLE
relocated the minimap expand button

### DIFF
--- a/client/src/components/Minimap/Minimap.tsx
+++ b/client/src/components/Minimap/Minimap.tsx
@@ -360,6 +360,16 @@ function Minimap(props: MinimapProps) {
               )}
             </div>
 
+            <button
+              className={`expandMinimapBtn ${props.minimapEnlarged && "hide"}`}
+              onClick={(): void => {
+                props.updateMinimapEnlarged(!props.minimapEnlarged);
+              }}
+            >
+              <span>Expand Minimap</span>
+              <i className="fas fa-expand-arrows-alt" />
+            </button>
+
             <div className="minimapButtons">
               {!pendingUpload && !props.minimapEnlarged && user?.isAdmin && (
                 <div

--- a/client/src/sass/partials/_minimap.module.scss
+++ b/client/src/sass/partials/_minimap.module.scss
@@ -14,6 +14,7 @@
     display: flex;
     flex-direction: row;
     gap: 0.5em;
+    // margin-bottom: 1.25rem;
   }
 
   .nameInput {
@@ -261,8 +262,8 @@
 
 .closeShow {
   position: absolute;
-  margin-top: -16px;
-  margin-right: -18px;
+  margin-top: -26px;
+  margin-right: 6px;
   padding: 3px 4px 2px 4px;
   font-size: 1em;
   z-index: 12;
@@ -272,6 +273,36 @@
   &:hover {
     transform: scale(1.2);
   }
+  // TEMP
+  display: none;
+}
+
+.expandMinimapBtn {
+  display: flex;
+  gap: 0.5em;
+  justify-content: center;
+  align-items: center;
+  height: 35px;
+  padding: 0.3em;
+  border-radius: 10px;
+  background-color: $prismPrimary;
+  border: $prismPrimary;
+  color: #fff;
+  font-size: 1em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.9;
+  cursor: pointer;
+  transition: 0.3s background-color ease;
+}
+
+.expandMinimapBtn:hover {
+  // ? TBD
+  background-color: #161a71;
+}
+
+.hide {
+  display: none;
 }
 
 .smallMapImg {

--- a/client/src/sass/partials/_minimap.module.scss
+++ b/client/src/sass/partials/_minimap.module.scss
@@ -253,16 +253,16 @@
   border: none;
   cursor: pointer;
   transition: left ease-out 0.19s;
-  color: black;
+  color: $prismPrimary;
   &:hover {
-    color: $prismPrimary;
+    color: black;
   }
 }
 
 .closeShow {
   position: absolute;
-  margin-top: 4px;
-  margin-right: 6px;
+  margin-top: -16px;
+  margin-right: -18px;
   padding: 3px 4px 2px 4px;
   font-size: 1em;
   z-index: 12;


### PR DESCRIPTION
**If need help setting up project:**
1. `./run_project_docker.sh` at prism root.
2.  Click Y for downloading mongodump data and if you need docker images built, click Y for that option too.
4. `mongorestore ./server/prism_mongodumps/anlb/mongodump_andrew_liveris_prd_2024_02_08/`
5. Navigate to `./server/env`
6. Change line 3:
```
DATABASE_URL=mongodb://mongodb:27017/andrew_liveris
```
Andrew liveris was used here as an example but feel free to use any other site.. like aeb for instance
7. Refer to **Setup**

**Setup:**
Please make sure you have client,server and db running.
Run `docker ps` to see your available containers. If no containers exist, run `docker compose up` or `docker compose up --build`
```bash
git checkout bugfix/TEAM24-303
```

**Testing:**
1. You are going to have to test manually, Users need to have the capability to click on the expand minimap button without obstructing the other nodes.

**Proposal**
I believe the current positioning of the expand button is not optimal. For example, allowing the minimap to be expanded simply by clicking on it seems to eliminate the need for a separate expand button, offering a more user-friendly approach. Could I get further opinions on this matter?
![Screenshot from 2024-03-19 12-00-09](https://github.com/UQ-eLIPSE/prism/assets/114811082/24d01870-4aeb-4cde-ae2e-942f21896342)

Ticket:
https://elipse-uq.atlassian.net/browse/TEAM24-303?atlOrigin=eyJpIjoiOWQ3ZTJjZWRkOGQ0NDU3MmI3ZDhiNmZmYTU0ZjA0NTQiLCJwIjoiaiJ9