### PR TITLE
Auto-Expand Timeline Month on Selection

### DIFF
--- a/client/src/components/Timeline.tsx
+++ b/client/src/components/Timeline.tsx
@@ -138,27 +138,35 @@ function Timeline(props: Props) {
     allSurveys: SurveyMonth[],
   ): React.ReactElement[] => {
     return allSurveys.map((month: SurveyMonth) => {
+      const handleButtonClick = (
+        month: SurveyMonth,
+        event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+      ) => {
+        event.stopPropagation();
+        showLatestSurveyInMonth(month, event);
+        setExpandedAccordian(
+          expandedAccordian === month.monthName ? "" : month.monthName,
+        );
+        setIsExpanded(expandedAccordian !== month.monthName);
+      };
+
       return (
         <div className={TimelineStyles.monthContainer} key={month.monthName}>
           <Accordion
             elevation={0}
             expanded={expandedAccordian === month.monthName}
+            onChange={() => {
+              setExpandedAccordian(
+                expandedAccordian === month.monthName ? "" : month.monthName,
+              );
+            }}
           >
             <AccordionSummary
               expandIcon={<i className={"fa fa-chevron-down fa-2x"} />}
             >
               <button
                 data-cy="month_button"
-                onClick={(event): void => {
-                  event.stopPropagation();
-                  showLatestSurveyInMonth(month, event);
-                  setExpandedAccordian(
-                    expandedAccordian === month.monthName
-                      ? ""
-                      : month.monthName,
-                  );
-                  setIsExpanded(expandedAccordian !== month.monthName);
-                }}
+                onClick={(event) => handleButtonClick(month, event)}
                 onFocus={(event) => event.stopPropagation()}
                 className={classNames(TimelineStyles.monthName, {
                   [TimelineStyles.currentMonth]:

--- a/client/src/components/Timeline.tsx
+++ b/client/src/components/Timeline.tsx
@@ -143,19 +143,22 @@ function Timeline(props: Props) {
           <Accordion
             elevation={0}
             expanded={expandedAccordian === month.monthName}
-            onChange={() => {
-              setExpandedAccordian(
-                expandedAccordian === month.monthName ? "" : month.monthName,
-              );
-              setIsExpanded(expandedAccordian !== month.monthName);
-            }}
           >
             <AccordionSummary
               expandIcon={<i className={"fa fa-chevron-down fa-2x"} />}
             >
               <button
                 data-cy="month_button"
-                onClick={(event): void => showLatestSurveyInMonth(month, event)}
+                onClick={(event): void => {
+                  event.stopPropagation();
+                  showLatestSurveyInMonth(month, event);
+                  setExpandedAccordian(
+                    expandedAccordian === month.monthName
+                      ? ""
+                      : month.monthName,
+                  );
+                  setIsExpanded(expandedAccordian !== month.monthName);
+                }}
                 onFocus={(event) => event.stopPropagation()}
                 className={classNames(TimelineStyles.monthName, {
                   [TimelineStyles.currentMonth]:


### PR DESCRIPTION
**If need help setting up project:**
1. `./run_project_docker.sh` at prism root.
2.  Click Y for downloading mongodump data and if you need docker images built, click Y for that option too.
4. `mongorestore ./server/prism_mongodumps/anlb/mongodump_andrew_liveris_prd_2024_02_08/`
5. Navigate to `./server/env`
6. Change line 3:
```
DATABASE_URL=mongodb://mongodb:27017/andrew_liveris
```
Andrew liveris was used here as an example but feel free to use any other site.. like aeb for instance
7. Refer to **Setup**

**Setup:**
Please make sure you have client,server and db running.
Run `docker ps` to see your available containers. If no containers exist, run `docker compose up` or `docker compose up --build`
```bash
git checkout bugfix/TEAM24-304
```

**Testing:**
1. You are going to have to test manually, Users should be able to expand the selected month to show all surveys contained within when pressing on the Timeline month (not just the down arrow)
